### PR TITLE
fix anon_root in template

### DIFF
--- a/templates/configfile.erb
+++ b/templates/configfile.erb
@@ -73,7 +73,7 @@ anon_umask=<%= @anon_umask %>
 # This option represents a directory which vsftpd will try to change into after an anonymous login. Failure is silently ignored.
 #
 # Default: (none)
-anon_root<%= @anon_root %>
+anon_root=<%= @anon_root %>
 <% end -%>
 <% if @ftp_username -%>
 # This is the name of the user we use for handling anonymous FTP. The home directory of this user is the root of the anonymous FTP area.


### PR DESCRIPTION
This bug is breaking config in a way which isn't recovered from subsequent puppet runs.